### PR TITLE
Adding support for property lookup and assignments.

### DIFF
--- a/src-test/reactive_test.js
+++ b/src-test/reactive_test.js
@@ -125,6 +125,114 @@ ReactiveTest.prototype.testStateInitialValue = function() {
   assertEquals(10, foo());
   assertUndefined(bar());
 }
+ReactiveTest.prototype.testObjectProperties = function() {
+  var obj = $R.state({ a: 10 });
+  assertEquals({ a: 10 }, obj());
+  assertEquals(10, obj.property('a')());
+}
+ReactiveTest.prototype.testArrayProperties = function() {
+  var obj = $R.state([ 10 ]);
+  assertEquals([ 10 ], obj());
+  assertEquals(10, obj.property(0)());
+  assertEquals(1, obj.property('length')());
+}
+ReactiveTest.prototype.testInvalidProperties = function() {
+  var obj = $R.state({ a: 10 });
+  assertEquals({ a: 10 }, obj());
+  assertEquals(10, obj.property('a')());
+  assertUndefined(obj.property('b')());
+  assertUndefined(obj.property('a').property('b')());
+}
+ReactiveTest.prototype.testObjectUpdates = function() {
+  var obj = $R.state({ a: 10 });
+  var ref = obj();
+
+  assertEquals({ a: 10 }, ref);
+  assertEquals({ a: 10 }, obj());
+  assertEquals(10, obj.property('a')());
+  assertUndefined(obj.property('a').property('b')());
+  assertUndefined(obj.property('c')());
+
+  obj({ a: { b: 12 }, c: 2 });
+
+  assertEquals({ a: 10 }, ref);
+  assertEquals({ a: { b: 12 }, c: 2 }, obj());
+  assertEquals({ b: 12 }, obj.property('a')());
+  assertEquals(12, obj.property('a').property('b')());
+  assertEquals(2, obj.property('c')());
+}
+ReactiveTest.prototype.testObjectPropertyUpdates = function() {
+  var obj = $R.state({ a: 10 });
+  var a = obj.property('a');
+  var double = $R(function(x) { return x * 2 }).bindTo(a);
+  var ref = obj();
+
+  assertEquals({ a: 10 }, ref);
+  assertEquals({ a: 10 }, obj());
+  assertEquals(10, a());
+  assertEquals(20, double());
+
+  a(12);
+
+  assertEquals({ a: 10 }, ref);
+  assertEquals({ a: 12 }, obj());
+  assertEquals(12, a());
+  assertEquals(24, double());
+}
+ReactiveTest.prototype.testDeepObjectUpdates = function() {
+  var obj = $R.state({ a: { b: { c: { d: 10 } } } });
+  var a = obj.property('a');
+  var b = a.property('b');
+  var c = b.property('c');
+  var d = c.property('d');
+  var double = $R(function(x) { return x * 2 }).bindTo(d);
+  var ref = obj();
+
+  assertEquals({ a: { b: { c: { d: 10 } } } }, ref);
+  assertEquals({ a: { b: { c: { d: 10 } } } }, obj());
+  assertEquals({ b: { c: { d: 10 } } }, a());
+  assertEquals({ c: { d: 10 } }, b());
+  assertEquals({ d: 10 }, c());
+  assertEquals(10, d());
+  assertEquals(20, double());
+
+  obj({ a: { b: { c: { d: 12 } } } });
+
+  assertEquals({ a: { b: { c: { d: 10 } } } }, ref);
+  assertEquals({ a: { b: { c: { d: 12 } } } }, obj());
+  assertEquals({ b: { c: { d: 12 } } }, a());
+  assertEquals({ c: { d: 12 } }, b());
+  assertEquals({ d: 12 }, c());
+  assertEquals(12, d());
+  assertEquals(24, double());
+}
+ReactiveTest.prototype.testDeepObjectPropertyUpdates = function() {
+  var obj = $R.state({ a: { b: { c: { d: 10 } } } });
+  var a = obj.property('a');
+  var b = a.property('b');
+  var c = b.property('c');
+  var d = c.property('d');
+  var double = $R(function(x) { return x * 2 }).bindTo(d);
+  var ref = obj();
+
+  assertEquals({ a: { b: { c: { d: 10 } } } }, ref);
+  assertEquals({ a: { b: { c: { d: 10 } } } }, obj());
+  assertEquals({ b: { c: { d: 10 } } }, a());
+  assertEquals({ c: { d: 10 } }, b());
+  assertEquals({ d: 10 }, c());
+  assertEquals(10, d());
+  assertEquals(20, double());
+
+  d(12);
+
+  assertEquals({ a: { b: { c: { d: 10 } } } }, ref);
+  assertEquals({ a: { b: { c: { d: 12 } } } }, obj());
+  assertEquals({ b: { c: { d: 12 } } }, a());
+  assertEquals({ c: { d: 12 } }, b());
+  assertEquals({ d: 12 }, c());
+  assertEquals(12, d());
+  assertEquals(24, double());
+}
 ReactiveTest.prototype.testTopologicalSort = function() {
   var aRan = 0;
   var bRan = 0;

--- a/src/reactive.js
+++ b/src/reactive.js
@@ -45,6 +45,9 @@
     _isReactive: true,
     toString: function () { return this.fnc.toString() },
     get: function() { return this.memo === $R.empty ? this.run() : this.memo },
+    property: function(name) {
+      return $R(property, this).bindTo(this, name);
+    },
     run: function() {
       var unboundArgs = Array.prototype.slice.call(arguments);
       return this.memo = this.fnc.apply(this.context, this.argumentList(unboundArgs));
@@ -105,5 +108,24 @@
 
   function wrap(v) {
     return v && (v._isReactive || v == $R._) ? v : $R(function () {return v});
+  }
+
+  function property(obj, name, value) {
+    if (arguments.length > 2) {
+      var ownProperty = {}.hasOwnProperty;
+
+      var Object = function(o, k, v) {
+        for (var key in o) {
+          if (ownProperty.call(o, key)) { this[key] = o[key] }
+        }
+        this[k] = v;
+        return this;
+      };
+      Object.prototype = obj.__proto__;
+
+      return this(new Object(obj, name, value));
+    } else {
+      try { return obj[name] } catch(e) { return undefined }
+    }
   }
 })();


### PR DESCRIPTION
Example:

``` javascript
var obj = $R.state({ a: 123 });

// Bindings to specific properties can be easily created.
var obj_a = obj.property('a');
var double = $R(function(x) { return x * 2 }).bindTo(obj_a);
double(); // => 246

// Those bindings react to changes in the underlying object.
obj({ a: 100 });
double(); // => 200

// They may also be used to set the property values directly...
obj_a(10);
double(); // => 20
obj(); // => { a: 10 }

// ... without disrupting existing references to the object.
var hash = obj(); // => { a: 10 }
obj_a(12);
obj(); // => { a: 12 }
hash; // => { a: 10 }

// Property lookups may also be chained, and update appropriately.
var obj_a_b = a.property('b')
double.bindTo(obj_a_b);

obj({ a: { b: 12 }});
double(); // => 24

obj_a({ b: 20 });
double(); // => 40

obj_a_b(30);
double(); // => 60
```

Possible improvements:
- Property lookups might benefit from a chained lookup shorthand.
  - e.g. `obj.property('a', 'b')` or `obj.property('a.b')`
- Property updates currently perform only a shallow clone; a deep clone may be warranted.
